### PR TITLE
Use Spring dependency management

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
    kotlin("plugin.spring") version "1.6.21"
 }
 
+apply(plugin = "io.spring.dependency-management")
+
 repositories {
    mavenCentral()
 }
@@ -14,21 +16,24 @@ group = "com.example"
 version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 
+extra["kotlinx-coroutines.version"] = "1.6.1"
+
 dependencies {
-   implementation(kotlin("stdlib"))
    implementation(kotlin("reflect"))
    implementation("org.springframework.boot:spring-boot-starter-webflux:2.7.0")
-   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3")
-   implementation("io.projectreactor.kotlin:reactor-kotlin-extensions:1.1.6")
-   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.6.1")
    testImplementation("org.springframework.boot:spring-boot-starter-test:2.7.0") {
       exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
       exclude(module = "mockito-core")
    }
    testImplementation("com.ninja-squad:springmockk:3.1.1")
-   testImplementation("io.projectreactor:reactor-test:3.4.18")
    testImplementation("io.kotest:kotest-runner-junit5:5.3.0")
    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.1")
+
+   // versions handled by spring dependency management plugin
+   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+   implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
+   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
+   testImplementation("io.projectreactor:reactor-test")
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
I think it's best practice to let Spring manage its dependencies, otherwise you can end up in a state where you have too new/old versions of something in the tree and it gets messy easily. 😄 